### PR TITLE
Bugfix and MacOS compatibility fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,39 @@
+# build trees
 build
+DEBUG*/*
+BUILD*/*
+RELEASE*/*
+TEST*/*
+
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+
+# cmake
+CMakeCache.txt
+CMakeFiles
+Makefile
+cmake_install.cmake
+install_manifest.txt
+
+# emacs/vim 
+~*
+*.swp
+*.swo
+
+# python
+__pycache__/
+*.py[cod]
+*$py.class
+.ipynb_checkpoints

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,13 @@ set(CMAKE_MODULE_PATH
    ${PROJECT_SOURCE_DIR}/cmake
    ${PROJECT_SOURCE_DIR}/cmake/modules)
 
+## Use C++17 features 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+## OS Specific settings
+include(cmake/os.cmake)
+
 find_package(LZ4 REQUIRED)
 add_definitions(-D__LZ4__)
 
@@ -13,7 +20,6 @@ list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS}/etc/cmake)
 find_package(ROOT REQUIRED COMPONENTS Tree)
 include(${ROOT_USE_FILE})
-#add_definitions(${ROOT_CXX_FLAGS})
 ## extra root settings
 include_directories(${ROOT_INCLUDE_DIRS})
 link_directories(${ROOT_LIBRARY_DIR})

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This code was adopted from source code on the jlab CUE
 Installing
 ----------
 
+**Note**: These instructions are for Linux. For MacOS, refer to the next subsection.
 ```
 git clone https://github.com/JeffersonLab/hipo_tools.git
 cd hipo_tools && mkdir build

--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ cmake ../. -DCMAKE_INSTALL_PREFIX=$HOME
 make && make install
 ```
 
+### Installing on MacOS
+
+For some reason XCode does not currently ship with the necessary C++17
+filesystem libraries (even though they have been available in LLVM for several
+versions). As temporary workaround, we suggest to install llvm through Homebrew:
+```
+brew install llvm
+```
+Homebrew will skip the linking step when you install llvm (as to not screw up
+your system), so you will have to tell cmake to use the newer version of
+llvm/clang. The installation instructions for MacOS are:
+```
+git clone https://github.com/JeffersonLab/hipo_tools.git
+cd hipo_tools && mkdir build
+cd build
+CXX=/usr/local/opt/llvm/bin/clang++ cmake ../. -DCMAKE_INSTALL_PREFIX=$HOME
+make && make install
+```
+
 ### Some tips
 
 * Use the latest version of root with the latest compiler (e.g. gcc8)

--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -1,10 +1,19 @@
-## OSX/homebrew version of root6 installs its cmake macros in a non-standard
-## location. This might be an issue on other systems as well.
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{ROOTSYS}/etc/root/cmake)
-endif()
-
-## Get rid of rpath warning on OSX
+## Get rid of rpath warning on OSX/MacOS
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(CMAKE_MACOSX_RPATH 1)
 endif()
+
+## Ensure the correct library for the "experimental" filesystem features is
+## loaded: 
+##    * Linux: libstdc++fs
+##    * MacOS (XCode) for some reason still doesn't include the filesystem
+##      features (this might change in XCode 10.0). Currently, a good way to get
+##      them is by installing llvm directly through homebrew. The correct
+##      library will then be:
+##      /usr/local/opt/lib/libc++experimental.a
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(CXX_FILESYSTEM_LIB "/usr/local/opt/llvm/lib/libc++experimental.a")
+else()
+  set(CXX_FILESYSTEM_LIB "stdc++fs")
+endif()
+

--- a/src/hipo-io/CMakeLists.txt
+++ b/src/hipo-io/CMakeLists.txt
@@ -10,8 +10,9 @@ target_include_directories(hipo_io
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
   )
+  #PRIVATE ${libname} stdc++fs
 target_link_libraries(hipo_io
-  PRIVATE ${libname} stdc++fs
+  PRIVATE ${libname} ${CXX_FILESYSTEM_LIB}
   PUBLIC hipocpp
   )
 

--- a/src/toohip4root/CMakeLists.txt
+++ b/src/toohip4root/CMakeLists.txt
@@ -60,8 +60,9 @@ target_include_directories(toohip4root
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
   )
+  #  PRIVATE ${libname} stdc++fs
 target_link_libraries(toohip4root
-  PRIVATE ${libname} stdc++fs
+  PRIVATE ${libname} ${CXX_FILESYSTEM_LIB}
   PUBLIC hiporoot
   PUBLIC ${ROOT_LIBRARIES} 
   )

--- a/src/toohip4root/include/THipo.h
+++ b/src/toohip4root/include/THipo.h
@@ -304,18 +304,18 @@ namespace hipo {
     std::vector<double_t> fVecD;
   };
   
-  /** Item for long.
+  /** Item for long (64 bit int).
    */
   class THipoItemL : public THipoItem {
 
   public:
-    THipoItemL(hipo::node<long>* node, Int_t* entry) : THipoItem(entry) {
+    THipoItemL(hipo::node<int64_t>* node, Int_t* entry) : THipoItem(entry) {
       fNodeL = node;
       fNode  = dynamic_cast<hipo::generic_node*>(fNodeL);
       fNode->type(8);
     };
     virtual ~THipoItemL(){};
-    virtual void ResetNode(hipo::node<long>* node) {
+    virtual void ResetNode(hipo::node<int64_t>* node) {
       fNodeL = nullptr;
       fNode  = nullptr;
       fNodeL = node;
@@ -342,11 +342,11 @@ namespace hipo {
       }
       return kFALSE;
     }
-    long Val() { return fNodeL->getValue(fBankEntry); }
+    int64_t Val() { return fNodeL->getValue(fBankEntry); }
 
   private:
-    hipo::node<long>* fNodeL = nullptr;
-    std::vector<long> fVecL;
+    hipo::node<int64_t>* fNodeL = nullptr;
+    std::vector<int64_t> fVecL;
   };
 
   /* inline Bool_t THipoItem::FindEntry(Float_t val){ */

--- a/src/toohip4root/src/THipo.cxx
+++ b/src/toohip4root/src/THipo.cxx
@@ -417,7 +417,7 @@ namespace hipo {
         break;
       case 8:
         dynamic_cast<THipoItemL*>(bank->GetItem(CodeToItem(vcode)))
-            ->ResetNode(fReader->getBranch<long>(bank->GetName(), CodeToItem(vcode).Data()));
+            ->ResetNode(fReader->getBranch<int64_t>(bank->GetName(), CodeToItem(vcode).Data()));
         break;
       default:
         break;


### PR DESCRIPTION
BUGFIX: 'long' was assumed to be 64 bits in part of the code, this is not true on all systems (e.g. on MacOS) -> Updated to use int64_t instead.

COMPATIBILTY: Load correct experimental C++ library to use <filesystem> on MacOS. Currently requires Homebrew version of LLVM (Xcode does not yet ship with <filesystem> for some reason). Updated the README with instructions for MacOS.