### PR TITLE
Added ROOT dictionary generation

### DIFF
--- a/src/toohip4root/CMakeLists.txt
+++ b/src/toohip4root/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.6)
-
 enable_testing()
 
 #SET(lib_VERSION "${${PROJECT_NAME}_VERSION}")
@@ -17,8 +16,11 @@ set(HEADERS
   #include/RHipoDS.h
   )
 
-#ROOT_GENERATE_DICTIONARY(${dictname} -I${PROJECT_SOURCE_DIR}/src/Hipo -I${PROJECT_SOURCE_DIR}/src/Hipo/include ${lib_HEADERS} LINKDEF ${lib_LINKDEF} OPTIONS -p)
-#ADD_CUSTOM_TARGET(${aname}_ROOTDICTS DEPENDS ${lib_SRCS} ${lib_HEADERS} ${lib_DICTIONARY_SRC} ${lib_DICTIONARY_HEADER})
+ROOT_GENERATE_DICTIONARY(toohip4rootDict 
+  -I${CMAKE_CURRENT_SOURCE_DIR} ${HEADERS} 
+  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/include/LinkDef.h
+  OPTIONS -p)
+ADD_CUSTOM_TARGET(toohip4rootDict_ROOTDICTS DEPENDS ${HEADERS} toohip4rootDict.cxx )
 
 message("ROOT_LIBRARIES ${ROOT_LIBRARIES} ")
 add_library(hiporoot SHARED 
@@ -26,6 +28,7 @@ add_library(hiporoot SHARED
   src/THipoItem.cxx
   src/THipoBank.cxx
   src/THipoBankParser.cxx
+  toohip4rootDict.cxx
   #src/RHipoDS.cxx
   )
 target_link_libraries(hiporoot 
@@ -49,7 +52,9 @@ install(
   EXPORT ${PROJECT_NAME}Targets
   DESTINATION lib )
 
-#install( FILES ${lib_PCM_FILE} DESTINATION lib )
+install( FILES ${CMAKE_CURRENT_BINARY_DIR}/toohip4rootDict_rdict.pcm 
+  DESTINATION lib )
+
 SET(lib_HEADERS ${HEADERS} ${template_headers})
 install(
   FILES ${HEADERS} 

--- a/src/toohip4root/include/LinkDef.h
+++ b/src/toohip4root/include/LinkDef.h
@@ -1,4 +1,4 @@
-#ifdef __CINT__
+#ifdef __CLING__
 
 #pragma link off all globals;
 #pragma link off all classes;
@@ -10,7 +10,10 @@
 
 #pragma link C++ namespace hipo;
 
-#pragma link C++ class hipo::THipo+;
+//#pragma link C++ class hipo::THipo+;
+
+#pragma link C++ class std::vector<signed char>+;
+
 
 //#pragma link C++ class CLAS12EventDisplay+;
 


### PR DESCRIPTION
Currently it only generates the dictionary needed for
`std::vector<signed char>`, which had a warning previously hidden by the overly
verbose printout.