### PR TITLE
fix trajectory pindex bug

### DIFF
--- a/src/hipo2root/hipo2root.cpp
+++ b/src/hipo2root/hipo2root.cpp
@@ -945,8 +945,8 @@ int main(int argc, char** argv) {
         REC_Traj_path_vec.resize(l);
 
         for (int i = 0; i < l; i++) {
-          REC_Traj_index_vec[i]    = rec_Traj->getInt(0, i);
-          REC_Traj_pindex_vec[i]   = rec_Traj->getInt(1, i);
+          REC_Traj_pindex_vec[i]   = rec_Traj->getInt(0, i);
+          REC_Traj_index_vec[i]    = rec_Traj->getInt(1, i);
           REC_Traj_detector_vec[i] = rec_Traj->getInt(2, i);
           REC_Traj_layer_vec[i]    = rec_Traj->getInt(3, i);
           REC_Traj_x_vec[i]        = rec_Traj->getFloat(4, i);


### PR DESCRIPTION
There is a bug in hipo2root utility with REC::Traj bank. It comes from the fact that in REC::Traj bank the order of ```index``` and ```pindex``` are reversed. E.g. in REC::Calorimeter, ```index``` is the first variable in the bank, and ```pindex``` is the second. And this order is the same in other banks that have ```index``` and ```pindex```. See screenshot below (clickable to increase the size):
<img src="https://user-images.githubusercontent.com/13206395/91651099-3544a680-ea56-11ea-8fa0-5e0f0111cb29.png" width=300>
 However, in REC::Traj the order is reversed, and ```pindex``` is the first, ```index``` is the second:
<img src="https://user-images.githubusercontent.com/13206395/91651088-134b2400-ea56-11ea-996d-63162b53001e.png" width=300>

In ```hipo2root``` utility, ```index``` and ```pindex``` are read in wrong order:
https://github.com/JeffersonLab/hipo_tools/blob/290c69988194c603d2a3d7ba01ad1cdf0848b428/src/hipo2root/hipo2root.cpp#L947-L951

******Note****** that in ```hipo2root3``` the order is correct:
https://github.com/JeffersonLab/hipo_tools/blob/290c69988194c603d2a3d7ba01ad1cdf0848b428/src/hipo2root/hipo2root3.cpp#L224-L226

I have confirmed it for one event 387247 in run 5032:
* REC::Traj bank from hipo file: <img src="https://user-images.githubusercontent.com/13206395/91651239-3a0a5a00-ea58-11ea-89fb-17d914636024.png" width=300>
* REC::Traj bank from converted root file: <img src="https://user-images.githubusercontent.com/13206395/91651253-76d65100-ea58-11ea-9705-ca053b8cf261.png" width=300>

